### PR TITLE
Whitespace normalizer optimizations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,6 +190,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +400,7 @@ dependencies = [
  "downcast-rs 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -507,6 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd7d911c5dc610aabe37caae7d3b9d2cfe6d8f4c85ff4c062f3d6f490e75067"
 "checksum gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edc95561e538381576425264a4ddd08c65d5da218f10b2a47b4479dd147775da"
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
+"checksum itertools 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "947aa0b9bb417792efa3936c5dada2d680b3bc27ea6a88ffa062f4c4d86ef8c5"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lalrpop 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8ebe5a5c90d5edeecb7f62f6ebec0a3d0f6faf4759a052708348cda99fd311a0"
 "checksum lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05410c1e4aff497bdea1ccb274ac35536fda0ee858600df36966502d4f7acbe3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,7 @@ downcast-rs = "^1.0.0"
 regex = "^0.2.1"
 lalrpop-util = "0.13.1"
 cssparser = "^0.18.2"
+itertools = "0.7.4"
 
 [dependencies.cairo-sys-rs]
 version = "0.4.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,6 +4,7 @@ extern crate cssparser;
 extern crate glib;
 extern crate glib_sys;
 extern crate libc;
+extern crate itertools;
 
 #[macro_use]
 extern crate downcast_rs;

--- a/rust/src/space.rs
+++ b/rust/src/space.rs
@@ -49,15 +49,8 @@ fn normalize_default(s: &str) -> String {
 // and "b") will produce a larger separation between "a" and "b" than
 // "a b" (one space between "a" and "b").
 fn normalize_preserve(s: &str) -> String {
-    s.chars()
-        .map(|ch| {
-            match ch {
-                '\n' | '\t' => ' ',
-
-                c => c
-            }
-        })
-        .collect()
+    let s = s.replace("\n", " ");
+    s.replace("\t", " ")
 }
 
 #[no_mangle]

--- a/rust/src/space.rs
+++ b/rust/src/space.rs
@@ -1,7 +1,6 @@
 use libc;
 use glib::translate::*;
 use itertools::Itertools;
-use std::borrow::Cow;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -30,8 +29,7 @@ pub fn xml_space_normalize(mode: XmlSpace, s: &str) -> String {
 // characters into space characters. Then, it will strip off all
 // leading and trailing space characters. Then, all contiguous space
 // characters will be consolidated.
-fn normalize_default<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
-    let s = s.into();
+fn normalize_default(s: &str) -> String {
     s.trim()
         .chars()
         .filter(|ch| *ch != '\n')

--- a/rust/src/space.rs
+++ b/rust/src/space.rs
@@ -1,6 +1,7 @@
 use libc;
 use glib::translate::*;
 use itertools::Itertools;
+use std::borrow::Cow;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -29,7 +30,8 @@ pub fn xml_space_normalize(mode: XmlSpace, s: &str) -> String {
 // characters into space characters. Then, it will strip off all
 // leading and trailing space characters. Then, all contiguous space
 // characters will be consolidated.
-fn normalize_default(s: &str) -> String {
+fn normalize_default<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
+    let s = s.into();
     s.chars()
         .filter(|ch| *ch != '\n')
         .collect::<String>()
@@ -48,7 +50,8 @@ fn normalize_default(s: &str) -> String {
 // xml:space="preserve", the string "a   b" (three spaces between "a"
 // and "b") will produce a larger separation between "a" and "b" than
 // "a b" (one space between "a" and "b").
-fn normalize_preserve(s: &str) -> String {
+fn normalize_preserve<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
+    let s = s.into();
     let s = s.replace("\n", " ");
     s.replace("\t", " ")
 }

--- a/rust/src/space.rs
+++ b/rust/src/space.rs
@@ -1,5 +1,6 @@
 use libc;
 use glib::translate::*;
+use itertools::Itertools;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -34,7 +35,6 @@ fn normalize_default(s: &str) -> String {
         .collect::<String>()
         // split at whitespace, also trims whitespace.
         .split_whitespace()
-        .collect::<Vec<_>>()
         .join(" ")
 }
 

--- a/rust/src/space.rs
+++ b/rust/src/space.rs
@@ -32,8 +32,8 @@ fn normalize_default(s: &str) -> String {
     s.chars()
         .filter(|ch| *ch != '\n')
         .collect::<String>()
-        .split(|ch| ch == ' ' || ch == '\t')
-        .filter(|s| s.len() > 0)
+        // split at whitespace, also trims whitespace.
+        .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
 }

--- a/rust/src/space.rs
+++ b/rust/src/space.rs
@@ -32,9 +32,7 @@ pub fn xml_space_normalize(mode: XmlSpace, s: &str) -> String {
 // characters will be consolidated.
 fn normalize_default<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
     let s = s.into();
-    s.chars()
-        .filter(|ch| *ch != '\n')
-        .collect::<String>()
+    s.replace('\n', "")
         // split at whitespace, also trims whitespace.
         .split_whitespace()
         .join(" ")
@@ -52,8 +50,8 @@ fn normalize_default<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
 // "a b" (one space between "a" and "b").
 fn normalize_preserve<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
     let s = s.into();
-    let s = s.replace("\n", " ");
-    s.replace("\t", " ")
+    let s = s.replace('\n', " ");
+    s.replace('\t', " ")
 }
 
 #[no_mangle]

--- a/rust/src/space.rs
+++ b/rust/src/space.rs
@@ -32,7 +32,9 @@ pub fn xml_space_normalize(mode: XmlSpace, s: &str) -> String {
 // characters will be consolidated.
 fn normalize_default<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
     let s = s.into();
-    s.replace('\n', "")
+    s.chars()
+        .filter(|ch| *ch != '\n')
+        .collect::<String>()
         // split at whitespace, also trims whitespace.
         .split_whitespace()
         .join(" ")
@@ -48,10 +50,16 @@ fn normalize_default<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
 // xml:space="preserve", the string "a   b" (three spaces between "a"
 // and "b") will produce a larger separation between "a" and "b" than
 // "a b" (one space between "a" and "b").
-fn normalize_preserve<'a, S: Into<Cow<'a, str>>>(s: S) -> String {
-    let s = s.into();
-    let s = s.replace('\n', " ");
-    s.replace('\t', " ")
+fn normalize_preserve(s: &str) -> String {
+    s.chars()
+        .map(|ch| {
+            match ch {
+                '\n' | '\t' => ' ',
+
+                c => c
+            }
+        })
+        .collect()
 }
 
 #[no_mangle]


### PR DESCRIPTION
Added itertools crate to use [`Itertools::join`](https://docs.rs/itertools/0.7.4/itertools/fn.join.html) instead of the std collect/join calls.
Replaced split/filter on tabs and spaces, with [`split_whitespace`](https://doc.rust-lang.org/std/primitive.str.html#method.split_whitespace) which trims whitespace on split.
``Replaced the custom map/match/collect on normalize_preserve with std::str::replace. I believe this also avoid unnecessary copies``

Possible further optimizations:

- [x] investigate if [`std::borrow::Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html) could be applied.
- [x] remove the `collect::String` call after filter on newlines.

It might be possible to avoit the collect() by doing `split('\n').filter(|s| !s.is_empty())` instead of filterting with `char != '\n'` but we need benchmarks before attempting something like that to be sure.

~~I don't know of a way to write benchmarks for private funtions that would allow the rest of the crate to compile with stable toolchain.~~

My rustfmt is currently broken so the formatting might be a bit off.